### PR TITLE
Bugfix: query-tables function to check recursive queries

### DIFF
--- a/src/views/honeysql/util.clj
+++ b/src/views/honeysql/util.clj
@@ -71,6 +71,7 @@
   [query]
   (set (concat
          (second-level-tables query :with)
+         (second-level-tables query :with-recursive)
          (second-level-tables query :join-lateral)
          (second-level-tables query :left-join-lateral)
          (from-tables query)

--- a/test/views/honeysql/util_test.clj
+++ b/test/views/honeysql/util_test.clj
@@ -1,0 +1,11 @@
+(ns views.honeysql.util-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [honeysql.core :as hsql]
+            [views.honeysql.util :as util]))
+
+(deftest query-tables-test
+  (testing "will return the list of tables in a recursive query"
+    (let [query (hsql/build
+                  {:with-recursive [[:test_query {:select [:foo] :from [:bar]}]]})]
+      (is (= #{:bar}
+             (util/query-tables query))))))


### PR DESCRIPTION
_This addresses:_
https://www.pivotaltracker.com/n/projects/848347/stories/137615695
The function `views.honeysql.utils/query-tables` does not return tables that are cited as part of a `:with-recursive` cte.

_By doing:_
Add `:with-recursive` to the list keys that are checked. Added a test for this.
