### PR TITLE
Bugfix: support set operations in query tables

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,8 @@
                               :username :env
                               :password :env}]]
 
-  :dependencies [[kirasystems/views "1.4.8"]
-                 [honeysql "0.6.3"]
+  :dependencies [[kirasystems/views "2.0.0"]
+                 [honeysql "0.9.1"]
                  [org.clojure/java.jdbc "0.5.8"]
                  [org.clojure/tools.logging "0.3.1"]]
   :plugins [[lein-ancient "0.6.10"]]

--- a/src/views/honeysql/util.clj
+++ b/src/views/honeysql/util.clj
@@ -1,8 +1,9 @@
-(ns views.honeysql.util
-  (:require
-    [honeysql.core :as hsql]
-    [honeysql.helpers :as hh]
-    [clojure.string :refer [split]]))
+(ns views.honeysql.util)
+
+#_(:require
+   [honeysql.core :as hsql]
+   [honeysql.helpers :as hh]
+   [clojure.string :refer [split]])
 
 ;; The following is used for full refresh views where we can have CTEs and
 ;; subselects in play.
@@ -66,19 +67,30 @@
   [query]
   (if-let [v (:delete-from query)] [v] []))
 
+(defn set-operations-tables
+  "return tables used in operands for the set operation op
+
+  note: HoneySQL currently support INTERSECT, UNION, UNION ALL as set
+  operations."
+  [query op]
+  (mapcat query-tables (op query)))
+
 (defn query-tables
   "Return all the tables in an sql statement."
   [query]
   (set (concat
-         (second-level-tables query :with)
-         (second-level-tables query :with-recursive)
-         (second-level-tables query :join-lateral)
-         (second-level-tables query :left-join-lateral)
-         (from-tables query)
-         (join-tables query :join)
-         (join-tables query :left-join)
-         (join-tables query :right-join)
-         (where-tables query)
-         (insert-tables query)
-         (update-tables query)
-         (delete-tables query))))
+        (second-level-tables query :with)
+        (second-level-tables query :with-recursive)
+        (second-level-tables query :join-lateral)
+        (second-level-tables query :left-join-lateral)
+        (from-tables query)
+        (join-tables query :join)
+        (join-tables query :left-join)
+        (join-tables query :right-join)
+        (where-tables query)
+        (insert-tables query)
+        (update-tables query)
+        (delete-tables query)
+        (set-operations-tables query :intersect)
+        (set-operations-tables query :union-all)
+        (set-operations-tables query :union))))

--- a/src/views/honeysql/util.clj
+++ b/src/views/honeysql/util.clj
@@ -1,10 +1,5 @@
 (ns views.honeysql.util)
 
-#_(:require
-   [honeysql.core :as hsql]
-   [honeysql.helpers :as hh]
-   [clojure.string :refer [split]])
-
 ;; The following is used for full refresh views where we can have CTEs and
 ;; subselects in play.
 

--- a/test/views/honeysql/util_test.clj
+++ b/test/views/honeysql/util_test.clj
@@ -4,8 +4,53 @@
             [views.honeysql.util :as util]))
 
 (deftest query-tables-test
+  (testing "will return the list of tables in a simple select from
+  table uery"
+    (let [query (hsql/build {:select [:field1]
+                             :from [:table1]})]
+      (is (= #{:table1}
+             (util/query-tables query)))))
+  (testing "will return the list of tables in a query containing a sub query"
+    (let [query (hsql/build {:with [[:sub_query {:select [:field2]
+                                                 :from [:table2]}]]
+                             :select [:field1]
+                             :from [:table1]})]
+      (is (= #{:table1 :table2}
+             (util/query-tables query)))))
+  (testing "will retun the list of tables used in a sub queries from a
+  compond query using set operation"
+    (testing "intersect"
+      (let [query (hsql/build {:intersect [{:select [:field1]
+                                            :from [:table1]}
+                                           {:select [:field2]
+                                            :from [:table2]}]})]
+        (is (= #{:table1 :table2}
+               (util/query-tables query)))))
+    (testing "union"
+      (let [query (hsql/build {:union [{:select [:field1]
+                                        :from [:table1]}
+                                       {:select [:field2]
+                                        :from [:table2]}]})]
+        (is (= #{:table1 :table2}
+               (util/query-tables query)))))
+    (testing "union all"
+      (let [query (hsql/build {:union-all [{:select [:field1]
+                                            :from [:table1]}
+                                           {:select [:field2]
+                                            :from [:table2]}]})]
+        (is (= #{:table1 :table2}
+               (util/query-tables query)))))
+    (testing "intersect as part of a sub query"
+      (let [query (hsql/build {:with [[:sub_query {:intersect [{:select [:field2]
+                                                                :from [:table2]}
+                                                               {:select [:field3]
+                                                                :from [:table3]}]}]]
+                               :select [:field1]
+                               :from [:table1 :table3]})]
+        (is (= #{:table1 :table2 :table3}
+               (util/query-tables query))))))
   (testing "will return the list of tables in a recursive query"
     (let [query (hsql/build
-                  {:with-recursive [[:test_query {:select [:foo] :from [:bar]}]]})]
+                 {:with-recursive [[:test_query {:select [:foo] :from [:bar]}]]})]
       (is (= #{:bar}
              (util/query-tables query))))))

--- a/test/views/honeysql/util_test.clj
+++ b/test/views/honeysql/util_test.clj
@@ -5,20 +5,20 @@
 
 (deftest query-tables-test
   (testing "will return the list of tables in a simple select from
-  table uery"
+  table query"
     (let [query (hsql/build {:select [:field1]
                              :from [:table1]})]
       (is (= #{:table1}
              (util/query-tables query)))))
-  (testing "will return the list of tables in a query containing a sub query"
+  (testing "will return the list of tables in a query containing a subquery"
     (let [query (hsql/build {:with [[:sub_query {:select [:field2]
                                                  :from [:table2]}]]
                              :select [:field1]
                              :from [:table1]})]
       (is (= #{:table1 :table2}
              (util/query-tables query)))))
-  (testing "will retun the list of tables used in a sub queries from a
-  compond query using set operation"
+  (testing "will return the list of tables used in subqueries from a
+  compound query using set operation"
     (testing "intersect"
       (let [query (hsql/build {:intersect [{:select [:field1]
                                             :from [:table1]}
@@ -40,7 +40,7 @@
                                             :from [:table2]}]})]
         (is (= #{:table1 :table2}
                (util/query-tables query)))))
-    (testing "intersect as part of a sub query"
+    (testing "intersect as part of a subquery"
       (let [query (hsql/build {:with [[:sub_query {:intersect [{:select [:field2]
                                                                 :from [:table2]}
                                                                {:select [:field3]


### PR DESCRIPTION
*This addresses:*
DEV-617 where the function views.honeysql.utils/query-tables does not return tables that are cited as part of compound queries using set operations like INTERSECT, UNION, UNION ALL.

*By doing:*
- Adding a function to extract a set operation and concatenating the tables of its subqueries. 
- This new function will be used by views.honeysql.utils/query-tables to extract tables from :intersect, :union, :union-all.
- clean up namespace
- upversion dependencies

note: the dependencies have been updated to the newest version of those projects and have jump multiple major versions with breaking changes. But this should not affect the views-honeysql project as the limited functionalities used by it was not affected. This could be problematic for a consumer that brings in these dependencies transitively. I don't think this should require a major upversion of views-honeysql as a consequence. 