### PR TITLE
[DEV-2998] add support for tables in :select and :exists

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kirasystems/views-honeysql "0.1.4"
+(defproject kirasystems/views-honeysql "0.1.5-SNAPSHOT"
   :description "HoneySQL view implementation for views"
   :url "https://github.com/kirasystems/views-honeysql"
   :license {:name "MIT License"

--- a/src/views/honeysql/util.clj
+++ b/src/views/honeysql/util.clj
@@ -45,6 +45,11 @@
     (map? wc)  [wc]
     :else      []))
 
+(defn select-tables
+  "Search for subqueries in the select clause."
+  [query]
+  (mapcat query-tables (collect-maps (:select query))))
+
 (defn where-tables
   "This search for subqueries in the where clause."
   [query]
@@ -70,6 +75,11 @@
   [query op]
   (mapcat query-tables (op query)))
 
+(defn exists-tables
+  [query]
+  (when (:exists query)
+    (query-tables (:exists query))))
+
 (defn query-tables
   "Return all the tables in an sql statement."
   [query]
@@ -82,10 +92,12 @@
         (join-tables query :join)
         (join-tables query :left-join)
         (join-tables query :right-join)
+        (select-tables query)
         (where-tables query)
         (insert-tables query)
         (update-tables query)
         (delete-tables query)
         (set-operations-tables query :intersect)
         (set-operations-tables query :union-all)
-        (set-operations-tables query :union))))
+        (set-operations-tables query :union)
+        (exists-tables query))))

--- a/test/views/honeysql/util_test.clj
+++ b/test/views/honeysql/util_test.clj
@@ -56,9 +56,12 @@
              (util/query-tables query)))))
 
   (testing "will return table in exists"
-    (let [query {:select [[{:exists {:select [1] :from [:foo]}} :col]] :from [:bar]}]
+    (let [in-select-query {:select [[{:exists {:select [1] :from [:foo]}} :col]] :from [:bar]}]
       (is (= #{:foo :bar}
-             (util/query-tables query)))))
+             (util/query-tables in-select-query))))
+    (let [in-where-query {:select [:col] :from [:bar] :where [:exists {:select [1] :from [:foo]}]}]
+      (is (= #{:foo :bar}
+             (util/query-tables in-where-query)))))
   (testing "will return table mentioned in select clause"
     (let [query {:select [[{:select [1] :from [:foo] :limit 1} :col]] :from [:bar]}]
       (is (= #{:foo :bar}

--- a/test/views/honeysql/util_test.clj
+++ b/test/views/honeysql/util_test.clj
@@ -53,4 +53,13 @@
     (let [query (hsql/build
                  {:with-recursive [[:test_query {:select [:foo] :from [:bar]}]]})]
       (is (= #{:bar}
+             (util/query-tables query)))))
+
+  (testing "will return table in exists"
+    (let [query {:select [[{:exists {:select [1] :from [:foo]}} :col]] :from [:bar]}]
+      (is (= #{:foo :bar}
+             (util/query-tables query)))))
+  (testing "will return table mentioned in select clause"
+    (let [query {:select [[{:select [1] :from [:foo] :limit 1} :col]] :from [:bar]}]
+      (is (= #{:foo :bar}
              (util/query-tables query))))))


### PR DESCRIPTION
https://kirasystems.atlassian.net/browse/DEV-2998
When table is referred to in the :select clause or is wrapped with :exists it was not being detected as a table to include into the hint.